### PR TITLE
Point semantic-search contract docs to Sherlock Search as canonical upstream

### DIFF
--- a/caps/semantic-search-bi/docs/README.md
+++ b/caps/semantic-search-bi/docs/README.md
@@ -1,5 +1,8 @@
 # semantic.search — Contract Only
 
+Canonical upstream for this contract package now lives in `SocioProphet/sherlock-search`.
+This SourceOS copy is retained as a mirror/reference so local docs and tooling do not break, but changes should land upstream first.
+
 This package defines contracts for a semantic search capability:
 - triRPC service surface (rpc/semantic.search.v0.yaml)
 - topic taxonomy for event bus integration (topics/*.yaml)

--- a/docs/semantic-search/README.md
+++ b/docs/semantic-search/README.md
@@ -1,5 +1,9 @@
 # Semantic Search Capability Contract (Contract-Only)
 
+Canonical upstream for these contracts now lives in `SocioProphet/sherlock-search`.
+This copy in SourceOS should be treated as a mirror/reference copy, not the contract owner.
+When updating the semantic-search contract, update `sherlock-search` first and then mirror or point here deliberately.
+
 This directory explains the **Semantic Search** capability contract in plain English.
 
 ## What this is
@@ -40,4 +44,3 @@ Start at:
 ## “BI” naming note
 If the folder is `caps/semantic-search-bi`, “bi” should mean *behavioral indexing* (or whatever we intended),
 not “business intelligence”. If that’s not what we mean, we should rename now while it’s early.
-

--- a/docs/semantic-search/UPSTREAM.md
+++ b/docs/semantic-search/UPSTREAM.md
@@ -1,0 +1,11 @@
+# Upstream ownership
+
+Canonical repository: `SocioProphet/sherlock-search`
+
+Canonical PR that moved ownership upstream:
+- `SocioProphet/sherlock-search#1`
+
+Policy for updates:
+1. Change the contract in `sherlock-search` first.
+2. Validate there.
+3. Mirror here only if SourceOS needs a local reference copy.


### PR DESCRIPTION
This PR keeps the existing SourceOS semantic-search contract copy as a mirror/reference, but makes ownership explicit now that the canonical contract has been upstreamed and merged into `SocioProphet/sherlock-search`.

What changes:
- `docs/semantic-search/README.md` now states that canonical upstream lives in `SocioProphet/sherlock-search`.
- `caps/semantic-search-bi/docs/README.md` now states that SourceOS is a mirror/reference copy and upstream changes should land in Sherlock Search first.
- `docs/semantic-search/UPSTREAM.md` records the ownership policy and links to the canonical upstream PR.

Why:
- Avoid contract drift between SourceOS and Sherlock Search.
- Preserve local paths/docs in SourceOS without treating it as the owner.

Canonical upstream PR already merged:
- `SocioProphet/sherlock-search#1`
