### PR TITLE
docs: add Truth Plane enforcement plan (surfaces, egress gate, incident semantics)

### DIFF
--- a/docs/TRUTH_PLANE.md
+++ b/docs/TRUTH_PLANE.md
@@ -10,6 +10,7 @@ This document specifies **how the SourceOS substrate enforces** the canonical co
 **Boundary:** this repo implements enforcement. Contract shapes live in `sourceos-spec`.
 
 See also:
+
 - `docs/BOUNDARIES.md` (layer separation).
 
 ---
@@ -43,6 +44,7 @@ SourceOS enforcement is implemented as a small set of system services with stric
 5) `sourceos-incident` — executes Freeze/Fork/Kill semantics and emits corresponding events.
 
 Each service:
+
 - runs with least privilege,
 - produces signed artifacts,
 - writes to an append-only local audit stream,
@@ -56,7 +58,7 @@ All enforcement artifacts live under a single root, so the system can snapshot, 
 
 Suggested layout:
 
-```
+```text
 /var/lib/sourceos/
   truth/
     surfaces/<plane>/<timestamp>/truth-surface.json
@@ -79,6 +81,7 @@ Suggested layout:
 ```
 
 Notes:
+
 - The audit log is **append-only**.
 - The evidence index points to local blobs (or sealed bundles) without duplicating them.
 - Replay-cache prevents grant reuse (nonce replay).
@@ -130,6 +133,7 @@ A **TruthSurface** is generated per plane:
 ### Determinism
 
 Surfaces must be deterministic given the same inputs:
+
 - stable ordering,
 - canonical JSON serialization,
 - explicit timestamps in metadata only.
@@ -155,6 +159,7 @@ A **DeltaSurface** is generated between two surfaces:
 - promotion recommendation (permit/deny/needs-more-evidence).
 
 Δ-surfaces must reference:
+
 - the two surface IDs/roots,
 - the policy pack digest used for evaluation.
 
@@ -169,6 +174,7 @@ Incidents are executed as explicit phases with corresponding immutable records.
 Objective: stop mutation and contain damage.
 
 Actions (example set):
+
 - stop or pause high-risk services,
 - block frontier egress unconditionally,
 - snapshot runtime truth buffers,
@@ -179,6 +185,7 @@ Actions (example set):
 Objective: produce a sealed forensic bundle.
 
 Actions:
+
 - bundle:
   - latest truth surfaces + delta surfaces,
   - runtime snapshots,
@@ -192,6 +199,7 @@ Actions:
 Objective: terminate compromised actors and return to safe posture.
 
 Actions:
+
 - terminate compromised processes/units,
 - revoke/expire relevant grants,
 - rotate sensitive local secrets if required,

--- a/docs/TRUTH_PLANE.md
+++ b/docs/TRUTH_PLANE.md
@@ -1,0 +1,229 @@
+# Truth Plane Enforcement (SourceOS)
+
+This document specifies **how the SourceOS substrate enforces** the canonical contract expectations defined in the spec layer (SourceOS-Linux/sourceos-spec), including:
+
+- Truth surfaces (B¹¹) + Δ-surfaces generation and attestation.
+- Policy-derived short-lived grants (CapabilityToken profile extensions) used for controlled actions (especially egress/frontier).
+- Explicit incident semantics: Freeze → Fork → Kill.
+- Runtime truth capture (process/thread provenance summaries) sufficient to detect trust collapse and support replay.
+
+**Boundary:** this repo implements enforcement. Contract shapes live in `sourceos-spec`.
+
+See also:
+- `docs/BOUNDARIES.md` (layer separation).
+
+---
+
+## 1. Trust boundaries and invariants
+
+### Invariants
+
+1. **Local-first**: core operations (surfaces, enforcement, audit) must function without internet.
+2. **Default deny for frontier egress**: off-box traffic is blocked unless explicitly allowed by a short-lived grant.
+3. **Artifact-first auditability**: every meaningful action emits an immutable record (event + evidence refs).
+4. **Human precedence**: sensitive actions require human approval according to policy.
+5. **Portability discipline**: enforcement MUST reference contracts by versioned schema IDs and produce conforming payloads.
+
+### Trust boundaries
+
+- **In-box**: local process execution, local networks (LAN/loopback), local store.
+- **Frontier**: any non-local network path (WAN, cloud APIs, external registries, etc.).
+- **Witness**: any external attestation/replication peer (optional but supported).
+
+---
+
+## 2. Enforcement architecture (services)
+
+SourceOS enforcement is implemented as a small set of system services with strict separation:
+
+1) `sourceos-truth-surface` — generates B¹¹ surfaces for each plane.
+2) `sourceos-delta-surface` — computes Δ-surfaces between two surfaces.
+3) `sourceos-gate-egress` — enforces default deny egress and installs short-lived allow rules derived from grants.
+4) `sourceos-runtime-truth` — collects runtime provenance summaries (process ancestry + thread clusters + namespace/cap changes).
+5) `sourceos-incident` — executes Freeze/Fork/Kill semantics and emits corresponding events.
+
+Each service:
+- runs with least privilege,
+- produces signed artifacts,
+- writes to an append-only local audit stream,
+- references canonical contract IDs from `sourceos-spec`.
+
+---
+
+## 3. Local store layout
+
+All enforcement artifacts live under a single root, so the system can snapshot, replay, and export a forensic bundle.
+
+Suggested layout:
+
+```
+/var/lib/sourceos/
+  truth/
+    surfaces/<plane>/<timestamp>/truth-surface.json
+    deltas/<from>__<to>/<timestamp>/delta-surface.json
+  audit/
+    events/<date>/events.ndjson
+    evidence-index.sqlite
+    signatures/<date>/*.sig
+  gate/
+    egress/
+      allowlist.state.json
+      replay-cache.sqlite
+  runtime/
+    snapshots/<timestamp>/{proc.json,threads.json,namespaces.json}
+  incidents/
+    <incident_id>/
+      freeze.json
+      fork.bundle.tar.zst
+      kill.json
+```
+
+Notes:
+- The audit log is **append-only**.
+- The evidence index points to local blobs (or sealed bundles) without duplicating them.
+- Replay-cache prevents grant reuse (nonce replay).
+
+---
+
+## 4. Egress gating (frontier deny-by-default)
+
+### Policy intent
+
+- LAN/loopback are permitted.
+- Frontier egress is denied unless a short-lived grant authorizes it.
+- Grants must be:
+  - derived from a policy decision,
+  - time-bounded (`exp`),
+  - replay-protected (nonce),
+  - scoped (targets + operations + optional frontier hop constraints).
+
+### Implementation sketch
+
+1) Firewall policy starts in **deny-by-default** mode for non-local destinations.
+2) `sourceos-gate-egress` listens on a local socket for “grant installed” events.
+3) When a grant is validated, it installs **temporary allow rules** for:
+   - specific destination CIDRs / hostnames (resolved deterministically and pinned for TTL),
+   - specific ports/protocols,
+   - a TTL window aligned with token `exp`.
+4) When TTL expires, rules are removed; a closure event is emitted.
+
+### Replay protection
+
+- Store `(tokenId, nonce)` in `replay-cache.sqlite`.
+- Reject if seen before or if `exp` is in the past.
+
+### Human approval integration
+
+If policy indicates human approval is required (e.g., commit-class or non-read prod), the gate must refuse to install allow rules unless approval proof is present.
+
+---
+
+## 5. Truth surfaces (B¹¹) generation
+
+A **TruthSurface** is generated per plane:
+
+- **system/sealed**: measured boot posture, OS fingerprint, policy pack digest, enforcement config digest.
+- **user/controlled**: declared intent + governed configs + approved workflows.
+- **agent/open**: execution decisions, sandbox posture, tool permissions, session receipts.
+- **witness** (optional): replication/attestation status.
+
+### Determinism
+
+Surfaces must be deterministic given the same inputs:
+- stable ordering,
+- canonical JSON serialization,
+- explicit timestamps in metadata only.
+
+### Attestation
+
+- compute a Merkle root over referenced artifacts,
+- sign the surface,
+- write both to `/var/lib/sourceos/truth/surfaces/...`.
+
+---
+
+## 6. Δ-surfaces generation
+
+A **DeltaSurface** is generated between two surfaces:
+
+- drift metrics (semantic/runtime/governance),
+- a gate evaluation block:
+  - evidence completeness,
+  - risk thresholds,
+  - approval requirements,
+  - integrity thresholds,
+- promotion recommendation (permit/deny/needs-more-evidence).
+
+Δ-surfaces must reference:
+- the two surface IDs/roots,
+- the policy pack digest used for evaluation.
+
+---
+
+## 7. Incident semantics: Freeze → Fork → Kill
+
+Incidents are executed as explicit phases with corresponding immutable records.
+
+### Freeze
+
+Objective: stop mutation and contain damage.
+
+Actions (example set):
+- stop or pause high-risk services,
+- block frontier egress unconditionally,
+- snapshot runtime truth buffers,
+- emit `incident.freeze` event with evidence refs.
+
+### Fork
+
+Objective: produce a sealed forensic bundle.
+
+Actions:
+- bundle:
+  - latest truth surfaces + delta surfaces,
+  - runtime snapshots,
+  - relevant audit slices,
+  - policy decisions/tokens involved,
+- seal bundle (hash + signature),
+- optionally replicate to witness.
+
+### Kill
+
+Objective: terminate compromised actors and return to safe posture.
+
+Actions:
+- terminate compromised processes/units,
+- revoke/expire relevant grants,
+- rotate sensitive local secrets if required,
+- emit `incident.kill` with remediation actions.
+
+---
+
+## 8. Acceptance tests (enforcement-level)
+
+These are the minimum behaviors we must be able to demonstrate:
+
+1. **Default deny**: frontier egress fails without a grant.
+2. **Scoped allow**: frontier egress succeeds only for granted targets/ports within TTL.
+3. **Replay protection**: reuse of the same token/nonce is rejected.
+4. **Evidence/approval enforcement**: when policy requires approval, the gate refuses without proof.
+5. **Surface determinism**: repeated surface generation is byte-stable (except explicit time fields).
+6. **Δ-surface gating**: gate results are reproducible and reference the policy pack digest.
+7. **Freeze stops mutation**: high-risk mutations stop; evidence is recorded.
+8. **Fork produces bundle**: bundle is sealed and replayable.
+9. **Kill is final**: actors terminated; grants revoked; closure events emitted.
+
+---
+
+## 9. Integration notes
+
+- Contract shapes and event types are imported from the canonical spec repo.
+- Risk/evidence/approval posture should mirror the policy-pack style in `sourceos-spec`.
+
+---
+
+## 10. Open questions (to close next)
+
+1. Which runtime provenance signals are mandatory for v0 (process ancestry only vs thread clusters + namespace transitions)?
+2. What is the minimal witness replication protocol (file transfer only vs signed event stream)?
+3. How do we represent “three human validators” in local enforcement state (keyring + rotation + emergency quorum collapse)?

--- a/docs/TRUTH_PLANE_IMPLEMENTATION.md
+++ b/docs/TRUTH_PLANE_IMPLEMENTATION.md
@@ -13,11 +13,13 @@ It exists to prevent scope drift: we list exactly what we implement first, what 
 We implement only the following, end-to-end:
 
 A. Default-deny frontier egress + short-lived allow windows
+
 - A firewall posture that permits loopback + LAN but denies non-local egress by default.
 - A local gate daemon that installs temporary allow rules derived from signed grants.
 - Replay protection for grants (nonce cache).
 
 B. Minimal TruthSurface emitter
+
 - Emit one TruthSurface for `system.sealed` that includes:
   - OS fingerprint + boot integrity posture summary,
   - policy pack digest(s),
@@ -25,6 +27,7 @@ B. Minimal TruthSurface emitter
   - references to relevant decisions/tokens/runs.
 
 C. Minimal DeltaSurface emitter
+
 - Emit one DeltaSurface comparing the last two `system.sealed` TruthSurfaces:
   - gate outcome (permit/deny/needs_more_evidence),
   - risk score vs threshold,
@@ -32,6 +35,7 @@ C. Minimal DeltaSurface emitter
   - references to evidence bundles.
 
 D. Incident Freeze (phase 1 only)
+
 - Implement `incident.freeze` as:
   - block all frontier egress immediately,
   - snapshot runtime truth buffers,
@@ -54,10 +58,12 @@ D. Incident Freeze (phase 1 only)
 ### A) Egress gate
 
 Components:
+
 - `sourceos-gate-egress` (daemon)
 - firewall ruleset (nftables preferred)
 
 Behavior:
+
 1. Start in default deny posture for non-local destinations.
 2. Accept a “grant install” request only over a local socket.
 3. Validate:
@@ -70,27 +76,33 @@ Behavior:
 ### B) TruthSurface emitter
 
 Components:
+
 - `sourceos-truth-surface` (daemon)
 
 Behavior:
+
 - Produces a `TruthSurface` payload conforming to `schemas/TruthSurface.json`.
 - Stores under `/var/lib/sourceos/truth/surfaces/system.sealed/<ts>/truth-surface.json`.
 
 ### C) DeltaSurface emitter
 
 Components:
+
 - `sourceos-delta-surface` (daemon)
 
 Behavior:
+
 - Produces a `DeltaSurface` payload conforming to `schemas/DeltaSurface.json`.
 - Stores under `/var/lib/sourceos/truth/deltas/system.sealed/<ts>/delta-surface.json`.
 
 ### D) Incident Freeze
 
 Components:
+
 - `sourceos-incident` (daemon)
 
 Behavior:
+
 - Emits `incident.freeze` payload conforming to `schemas/control-plane/incident-events.schema.json`.
 - Takes configured actions and records evidence refs.
 
@@ -123,4 +135,3 @@ Behavior:
 - [ ] TruthSurface emitter skeleton + signer
 - [ ] DeltaSurface emitter skeleton + gate evaluator
 - [ ] incident.freeze executor + event emitter
-

--- a/docs/TRUTH_PLANE_IMPLEMENTATION.md
+++ b/docs/TRUTH_PLANE_IMPLEMENTATION.md
@@ -1,0 +1,126 @@
+# Truth Plane Implementation Slice (v0)
+
+This document is the **v0 implementation slice** for the Truth Plane described in `docs/TRUTH_PLANE.md`.
+
+It exists to prevent scope drift: we list exactly what we implement first, what we defer, and what acceptance behaviors prove it works.
+
+**Boundary reminder:** contract shapes live in `SourceOS-Linux/sourceos-spec`; this repo implements enforcement.
+
+---
+
+## 1) Scope (v0)
+
+We implement only the following, end-to-end:
+
+A. Default-deny frontier egress + short-lived allow windows
+- A firewall posture that permits loopback + LAN but denies non-local egress by default.
+- A local gate daemon that installs temporary allow rules derived from signed grants.
+- Replay protection for grants (nonce cache).
+
+B. Minimal TruthSurface emitter
+- Emit one TruthSurface for `system.sealed` that includes:
+  - OS fingerprint + boot integrity posture summary,
+  - policy pack digest(s),
+  - evidence completeness panel,
+  - references to relevant decisions/tokens/runs.
+
+C. Minimal DeltaSurface emitter
+- Emit one DeltaSurface comparing the last two `system.sealed` TruthSurfaces:
+  - gate outcome (permit/deny/needs_more_evidence),
+  - risk score vs threshold,
+  - evidence present/missing list,
+  - references to evidence bundles.
+
+D. Incident Freeze (phase 1 only)
+- Implement `incident.freeze` as:
+  - block all frontier egress immediately,
+  - snapshot runtime truth buffers,
+  - pause a configurable list of “high risk” units,
+  - emit an incident event record.
+
+---
+
+## 2) Explicit deferrals (not v0)
+
+- Fork + Kill full automation (Fork bundle sealing, Kill remediation flows).
+- Full runtime truth plane (thread clustering, namespace transition detection at depth).
+- OpenAPI/AsyncAPI service surfaces hosted on the substrate.
+- In-place CapabilityToken schema extension (we rely on the spec layer to finalize the token profile).
+
+---
+
+## 3) Implementation notes (how we wire it)
+
+### A) Egress gate
+
+Components:
+- `sourceos-gate-egress` (daemon)
+- firewall ruleset (nftables preferred)
+
+Behavior:
+1. Start in default deny posture for non-local destinations.
+2. Accept a “grant install” request only over a local socket.
+3. Validate:
+   - signature (implementation-specific),
+   - expiry,
+   - nonce not previously seen.
+4. Install temporary allow rules for the requested targets/ports.
+5. Remove allow rules at expiry and emit a closure record.
+
+### B) TruthSurface emitter
+
+Components:
+- `sourceos-truth-surface` (daemon)
+
+Behavior:
+- Produces a `TruthSurface` payload conforming to `schemas/TruthSurface.json`.
+- Stores under `/var/lib/sourceos/truth/surfaces/system.sealed/<ts>/truth-surface.json`.
+
+### C) DeltaSurface emitter
+
+Components:
+- `sourceos-delta-surface` (daemon)
+
+Behavior:
+- Produces a `DeltaSurface` payload conforming to `schemas/DeltaSurface.json`.
+- Stores under `/var/lib/sourceos/truth/deltas/system.sealed/<ts>/delta-surface.json`.
+
+### D) Incident Freeze
+
+Components:
+- `sourceos-incident` (daemon)
+
+Behavior:
+- Emits `incident.freeze` payload conforming to `schemas/control-plane/incident-events.schema.json`.
+- Takes configured actions and records evidence refs.
+
+---
+
+## 4) Acceptance behaviors (v0 must pass)
+
+1. Default deny: non-local egress fails without a grant.
+2. Scoped allow: egress succeeds only for granted targets and only within TTL.
+3. Replay protection: reusing the same nonce/token is rejected.
+4. TruthSurface is emitted and schema-valid.
+5. DeltaSurface is emitted and schema-valid.
+6. Freeze blocks frontier egress immediately and emits an incident.freeze event record.
+
+---
+
+## 5) Contract links (normative references)
+
+- TruthSurface schema: `SourceOS-Linux/sourceos-spec/schemas/TruthSurface.json`
+- DeltaSurface schema: `SourceOS-Linux/sourceos-spec/schemas/DeltaSurface.json`
+- Incident events schema: `SourceOS-Linux/sourceos-spec/schemas/control-plane/incident-events.schema.json`
+
+---
+
+## 6) Work items (v0 checklist)
+
+- [ ] nftables baseline default-deny + LAN/loopback allow
+- [ ] replay cache storage (sqlite)
+- [ ] gate daemon skeleton + allow-rule installer
+- [ ] TruthSurface emitter skeleton + signer
+- [ ] DeltaSurface emitter skeleton + gate evaluator
+- [ ] incident.freeze executor + event emitter
+


### PR DESCRIPTION
Adds docs/TRUTH_PLANE.md describing how the SourceOS substrate enforces the canonical contract layer: truth surfaces + delta surfaces generation/attestation, default-deny frontier egress with short-lived grants, runtime truth capture, and explicit Freeze→Fork→Kill incident semantics.

Boundary preserved: contract shapes live in SourceOS-Linux/sourceos-spec; this repo implements enforcement. See docs/BOUNDARIES.md.
