### PR TITLE
sourceos: add artifact-truth scaffold for flavors, installer, channels, and manifests

### DIFF
--- a/butane/README.md
+++ b/butane/README.md
@@ -1,0 +1,5 @@
+# Butane source material
+
+This directory holds Butane source fragments and profile inputs that feed installer customization or first-boot provisioning.
+
+The intent is to keep SourceOS-specific, flavor-owned Butane source here while execution/rendering automation lives downstream.

--- a/butane/workstation/base.bu
+++ b/butane/workstation/base.bu
@@ -1,0 +1,12 @@
+variant: fcos
+version: 1.6.0
+passwd:
+  users:
+    - name: sourceos
+      groups:
+        - wheel
+      ssh_authorized_keys: []
+storage:
+  files: []
+systemd:
+  units: []

--- a/channels/README.md
+++ b/channels/README.md
@@ -3,6 +3,7 @@
 This directory holds SourceOS release-channel declarations.
 
 A channel defines the logical promotion lane for artifact families such as:
+
 - dev
 - qa
 - prod

--- a/channels/README.md
+++ b/channels/README.md
@@ -1,0 +1,11 @@
+# Release channels
+
+This directory holds SourceOS release-channel declarations.
+
+A channel defines the logical promotion lane for artifact families such as:
+- dev
+- qa
+- prod
+- customer or site-specific rings
+
+Channel policy and promotion automation are executed downstream; this repo owns the declared channel truth.

--- a/channels/dev.yaml
+++ b/channels/dev.yaml
@@ -1,5 +1,5 @@
+---
 apiVersion: sourceos.ai/v0
-kind: ReleaseChannel
 metadata:
   name: dev
 spec:

--- a/channels/dev.yaml
+++ b/channels/dev.yaml
@@ -1,0 +1,13 @@
+apiVersion: sourceos.ai/v0
+kind: ReleaseChannel
+metadata:
+  name: dev
+spec:
+  description: Development and integration ring for pre-production SourceOS artifacts.
+  promotionTargets:
+    - qa
+  allowedFlavors:
+    - sourceos-workstation
+  defaultInstallerProfiles:
+    - live-usb-default
+    - pxe-default

--- a/channels/dev.yaml
+++ b/channels/dev.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: sourceos.ai/v0
+kind: ReleaseChannel
 metadata:
   name: dev
 spec:

--- a/cosa/README.md
+++ b/cosa/README.md
@@ -1,0 +1,10 @@
+# coreos-assembler / image composition source
+
+This directory is the landing zone for FCOS/SourceOS image composition source material.
+
+It should eventually contain:
+- config-git inputs for coreos-assembler
+- tree/manifests for thicker derivative lanes
+- release-build metadata and helper notes
+
+This directory is artifact truth only. Build orchestration belongs in `socios`.

--- a/cosa/README.md
+++ b/cosa/README.md
@@ -3,6 +3,7 @@
 This directory is the landing zone for FCOS/SourceOS image composition source material.
 
 It should eventually contain:
+
 - config-git inputs for coreos-assembler
 - tree/manifests for thicker derivative lanes
 - release-build metadata and helper notes

--- a/docs/ARTIFACT_TRUTH.md
+++ b/docs/ARTIFACT_TRUTH.md
@@ -22,6 +22,7 @@ This repo owns the definitions of **what** gets built and released, not the auto
 - generic execution control plane behavior
 
 Those belong respectively in:
+
 - `SociOS-Linux/socios`
 - `SociOS-Linux/workstation-contracts`
 - `SocioProphet/sociosphere`
@@ -40,6 +41,7 @@ Those belong respectively in:
 ## Follow-on
 
 Subsequent changes should:
+
 - replace stubs with canonical flavor and installer schemas aligned to `sourceos-spec`
 - bind artifact manifests to `ReleaseManifest` / `EvidenceBundle` families
 - add FCOS-specific build-source structure under `cosa/`

--- a/docs/ARTIFACT_TRUTH.md
+++ b/docs/ARTIFACT_TRUTH.md
@@ -1,0 +1,45 @@
+# SourceOS artifact truth
+
+`SourceOS` is the immutable substrate and artifact-truth repository for the Linux-side stack.
+
+This repo owns the definitions of **what** gets built and released, not the automation that stands builders up or the control plane that executes workflows.
+
+## This repo owns
+
+- flavor definitions
+- coreos-assembler / image-composition source material
+- Butane / Ignition source material
+- installer profile definitions
+- release channels
+- artifact manifests and release metadata
+
+## This repo does not own
+
+- Foreman/Katello management host automation
+- Tekton / Argo CD execution scaffolding
+- workspace controller logic
+- runner↔adapter protocol contracts
+- generic execution control plane behavior
+
+Those belong respectively in:
+- `SociOS-Linux/socios`
+- `SociOS-Linux/workstation-contracts`
+- `SocioProphet/sociosphere`
+- `SocioProphet/agentplane`
+- `SourceOS-Linux/sourceos-spec`
+
+## Directory intent
+
+- `flavors/` — named SourceOS flavor definitions
+- `cosa/` — coreos-assembler or build-source material
+- `butane/` — Butane source fragments and rendered-input source material
+- `installer/` — installer profile definitions for live ISO / PXE / recovery surfaces
+- `channels/` — release-channel declarations
+- `manifests/` — artifact manifests and release metadata
+
+## Follow-on
+
+Subsequent changes should:
+- replace stubs with canonical flavor and installer schemas aligned to `sourceos-spec`
+- bind artifact manifests to `ReleaseManifest` / `EvidenceBundle` families
+- add FCOS-specific build-source structure under `cosa/`

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -48,6 +48,7 @@ We consider **Truth Plane v0.1** achieved when:
 - A compatibility alias remains for at least one minor cycle.
 
 Example:
+
 - `_nft_set_elements_json_from_obj` is a compatibility alias for `parse_nft_set_elements_json` and will be removed after v0.1.
 
 ---

--- a/flavors/README.md
+++ b/flavors/README.md
@@ -1,0 +1,14 @@
+# SourceOS flavors
+
+This directory holds named SourceOS flavor definitions.
+
+A flavor is the stable substrate family that downstream automation composes into install media, disk images, or promoted release artifacts.
+
+## Intended contents
+
+- base flavor descriptors
+- flavor-specific package/image composition inputs
+- flavor policy notes
+- flavor-level metadata used by release channels
+
+See `sourceos-workstation.example.yaml` for the initial stub.

--- a/flavors/sourceos-workstation.example.yaml
+++ b/flavors/sourceos-workstation.example.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: sourceos.ai/v0
+kind: Flavor
 metadata:
   name: sourceos-workstation
   labels:

--- a/flavors/sourceos-workstation.example.yaml
+++ b/flavors/sourceos-workstation.example.yaml
@@ -1,5 +1,5 @@
+---
 apiVersion: sourceos.ai/v0
-kind: Flavor
 metadata:
   name: sourceos-workstation
   labels:

--- a/flavors/sourceos-workstation.example.yaml
+++ b/flavors/sourceos-workstation.example.yaml
@@ -1,0 +1,21 @@
+apiVersion: sourceos.ai/v0
+kind: Flavor
+metadata:
+  name: sourceos-workstation
+  labels:
+    family: workstation
+    substrate: fcos
+spec:
+  baseStream: stable
+  architecture:
+    - x86_64
+  buildMode: thin-personalization
+  releaseChannels:
+    - dev
+    - qa
+    - prod
+  installerProfiles:
+    - live-usb-default
+    - pxe-default
+  butaneRefs:
+    - butane/workstation/base.bu

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,6 +1,7 @@
 # Installer profiles
 
 This directory holds installer profile definitions for SourceOS artifact surfaces such as:
+
 - customized live USB / recovery media
 - PXE / UEFI HTTP boot install surfaces
 - other future install or recovery delivery modes

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,8 @@
+# Installer profiles
+
+This directory holds installer profile definitions for SourceOS artifact surfaces such as:
+- customized live USB / recovery media
+- PXE / UEFI HTTP boot install surfaces
+- other future install or recovery delivery modes
+
+Profiles here are artifact-truth inputs. Media customization and publishing automation live in `socios`.

--- a/installer/live-usb-default.yaml
+++ b/installer/live-usb-default.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: sourceos.ai/v0
+kind: InstallerProfile
 metadata:
   name: live-usb-default
   labels:

--- a/installer/live-usb-default.yaml
+++ b/installer/live-usb-default.yaml
@@ -1,5 +1,5 @@
+---
 apiVersion: sourceos.ai/v0
-kind: InstallerProfile
 metadata:
   name: live-usb-default
   labels:

--- a/installer/live-usb-default.yaml
+++ b/installer/live-usb-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: sourceos.ai/v0
+kind: InstallerProfile
+metadata:
+  name: live-usb-default
+  labels:
+    surface: live-usb
+spec:
+  baseArtifact: fcos-live-iso
+  ignitionMode: embed-live-and-dest
+  networkMode: optional-keyfiles
+  secureBoot: true
+  enrollmentProfileRef: urn:srcos:enrollment-profile:default-workstation

--- a/installer/pxe-default.yaml
+++ b/installer/pxe-default.yaml
@@ -1,0 +1,14 @@
+apiVersion: sourceos.ai/v0
+kind: InstallerProfile
+metadata:
+  name: pxe-default
+  labels:
+    surface: pxe
+spec:
+  baseArtifact: fcos-live-pxe
+  transport: uefi-http-boot
+  ignitionMode: dest-only
+  kernelArgs:
+    - ignition.firstboot
+    - ignition.platform.id=metal
+  enrollmentProfileRef: urn:srcos:enrollment-profile:default-workstation

--- a/installer/pxe-default.yaml
+++ b/installer/pxe-default.yaml
@@ -1,5 +1,5 @@
+---
 apiVersion: sourceos.ai/v0
-kind: InstallerProfile
 metadata:
   name: pxe-default
   labels:

--- a/installer/pxe-default.yaml
+++ b/installer/pxe-default.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: sourceos.ai/v0
+kind: InstallerProfile
 metadata:
   name: pxe-default
   labels:

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,7 @@
+# Artifact manifests
+
+This directory holds release and artifact metadata emitted or curated as part of SourceOS artifact truth.
+
+The long-term direction is to align these manifests with the shared `ReleaseManifest` and `EvidenceBundle` families in `sourceos-spec`.
+
+Automation that generates, signs, publishes, and promotes these manifests lives downstream in `socios` and related execution/control surfaces.

--- a/manifests/release-manifest.example.json
+++ b/manifests/release-manifest.example.json
@@ -1,0 +1,22 @@
+{
+  "id": "urn:srcos:release:sourceos-workstation-dev-0001",
+  "type": "ReleaseManifest",
+  "specVersion": "2.0.0",
+  "sourceBuildRequestRef": "urn:srcos:build-request:sourceos-workstation-dev-0001",
+  "artifactRefs": [
+    "artifacts/sourceos-workstation-dev.iso"
+  ],
+  "artifactHashes": [
+    "sha256:REPLACE_WITH_REAL_DIGEST"
+  ],
+  "sbomRefs": [],
+  "evidenceRefs": [],
+  "labels": {
+    "flavor": "sourceos-workstation",
+    "channel": "dev",
+    "surface": "live-usb"
+  },
+  "channel": "dev",
+  "status": "draft",
+  "createdAt": "1970-01-01T00:00:00Z"
+}


### PR DESCRIPTION
## Summary

This PR adds the first bounded artifact-truth scaffold to `SourceOS`.

It complements the new `socios` substrate automation scaffold by giving the substrate repo a reviewable place for:
- flavor definitions
- FCOS/coreos-assembler source material
- Butane source material
- installer profiles
- release channels
- artifact manifests

## What lands

### Boundary note
- `docs/ARTIFACT_TRUTH.md`

### Directories and stubs
- `flavors/README.md`
- `flavors/sourceos-workstation.example.yaml`
- `cosa/README.md`
- `butane/README.md`
- `butane/workstation/base.bu`
- `installer/README.md`
- `installer/live-usb-default.yaml`
- `installer/pxe-default.yaml`
- `channels/README.md`
- `channels/dev.yaml`
- `manifests/README.md`
- `manifests/release-manifest.example.json`

## Why here

`SourceOS` already defines itself as the immutable substrate and explicitly says it is the substrate rather than the builder.

That makes it the correct place to hold the definitions of **what** gets built and released, while leaving orchestration and provisioning automation to `socios`.

## Important non-goals in this PR

This PR does **not** yet add:
- full coreos-assembler config-git material
- real package / tree manifests
- rendered Ignition outputs
- live artifact digests
- signing or promotion automation
- Foreman/Katello automation
- Tekton or Argo CD execution logic

Those belong downstream in `socios` or later follow-on tranches.

## Relationship to the broader effort

This PR is the substrate-side counterpart to:
- `workspace-inventory` graph expansion
- `workstation-contracts` M2 IPC pack
- `sourceos-spec` shared content/build/release family
- `socios` FCOS + Foreman/Katello substrate automation scaffold

Together, those changes move the original build/provisioning goal out of chat and into the actual repo authorities.
