### PR TITLE
feat: add SourceOS module and lane scaffolding

### DIFF
--- a/docs/operations/stage-and-rollback-lane.md
+++ b/docs/operations/stage-and-rollback-lane.md
@@ -1,0 +1,22 @@
+# Stage and rollback lane
+
+This note captures the first operational expectations for the Fedora Asahi + Nix control-plane lane.
+
+## Required flow
+
+1. build candidate inputs
+2. stage candidate in an isolated lane
+3. run smoke checks
+4. activate on host only after stage success
+5. verify host health
+6. keep or roll back
+
+## Rollback surfaces
+
+- generation rollback
+- image rollback
+- snapshot rollback
+
+## Non-goal
+
+This document does not yet prescribe the exact shell tooling. It exists to keep the operational sequence stable while the implementation modules are still being built out.

--- a/nix/modules/home/services/hn-tick.nix
+++ b/nix/modules/home/services/hn-tick.nix
@@ -1,0 +1,25 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.sourceos.services.hnTick;
+in
+{
+  options.sourceos.services.hnTick = {
+    enable = lib.mkEnableOption "hn-tick service";
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/state/hn-tick";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.hn-tick = {
+      Unit.Description = "SourceOS hn-tick service";
+      Service = {
+        Type = "simple";
+        ExecStart = "${pkgs.coreutils}/bin/true";
+        WorkingDirectory = cfg.stateDir;
+      };
+      Install.WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/nix/modules/stage/vm.nix
+++ b/nix/modules/stage/vm.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+{
+  options.sourceos.stage.vm = {
+    enable = lib.mkEnableOption "SourceOS stage VM lane";
+    candidateRef = lib.mkOption {
+      type = lib.types.str;
+      default = ".#stage-vm";
+      description = "Installable reference for the stage VM candidate.";
+    };
+  };
+}

--- a/nix/modules/storage/mount-classes.nix
+++ b/nix/modules/storage/mount-classes.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+{
+  options.sourceos.storage.mounts = lib.mkOption {
+    type = lib.types.listOf lib.types.attrs;
+    default = [ ];
+    description = "Declared mount classes for SourceOS substrate lanes.";
+  };
+}


### PR DESCRIPTION
Adds follow-up module and operations scaffolding for the Fedora Asahi + Nix substrate lane.